### PR TITLE
Change 1 and suggestion

### DIFF
--- a/HashTab.cpp
+++ b/HashTab.cpp
@@ -478,11 +478,8 @@ void HashTab::readFile(std::string filename){
     }
 
     string wrd;
-    while(!in_stream.eof()){//loops through all words in file
-
-        wrd = "";
-        getline(in_stream, wrd, ' ');
-
+    while(getline(in_stream,wrd,' '))
+{
         if(wrd != ""){
             int p;
             p = hashSum(wrd);//finds key for word read in


### PR DESCRIPTION
eof() is set after extraction of data from the file. You cannot use it like that in a loop. the first time eof() is called in the while loop it is not defined. Refer to this:
http://stackoverflow.com/questions/5605125/why-is-iostreameof-inside-a-loop-condition-considered-wrong

Also You actually should not use that space checker at the end of getline(in_stream,wrd,' ') because then the getline does not get lines! It only looks for a space to stop extracting. For instance if you have this:
a
b
the getline function returns this : a\nb\n. So I would change that and then split the words in each line inside the while loop.

and Finally, I have found a great source for huge text files which can be very useful for your program for seeing how good the hash function is:
http://introcs.cs.princeton.edu/java/data/
For example a good data set from this site is the words in the complete works of Shakespeare with 29166 words! This is the URL:
http://introcs.cs.princeton.edu/java/data/words.shakespeare.txt
