### PR TITLE
Solved bug and corrected print statement

### DIFF
--- a/HashTab.cpp
+++ b/HashTab.cpp
@@ -158,7 +158,7 @@ void HashTab::dispCode(){
     }
 
     cout << "return p;" << endl;
-    cin.get();
+    //cin.get();        //Unnecessary and prevents return to menu
 }
 
 /*

--- a/HashTab.cpp
+++ b/HashTab.cpp
@@ -577,17 +577,26 @@ void HashTab::currentSpecs(){
     double tsizeD = tsize;
 
     //calculates the average table depth based on the sum of all depths and the total table size
-    if(used>0){
+    if(used > (tsizeD/2) || totwords > 10){         //Only calculate average depth when >half slots are filled or there are >10 words entered
         avgdep = sumdepD/tsizeD;
+        cout << "Hash function: " << hashfunc << endl;
+        cout << "Table size: " << tsize << endl;
+        cout << "Total words: " << totwords << endl;
+        cout << "Total collisions: " << col << endl;
+        cout << "Slots used: " << used << endl;
+        cout << "Max depth: " << maxdep << endl;
+        cout << "Average depth: " << avgdep << endl;
     }
-
-    cout << "Hash function: " << hashfunc << endl;
-    cout << "Table size: " << tsize << endl;
-    cout << "Total words: " << totwords << endl;
-    cout << "Total collisions: " << col << endl;
-    cout << "Slots used: " << used << endl;
-    cout << "Max depth: " << maxdep << endl;
-    cout << "Average depth: " << avgdep << endl;
+    else
+    {
+        cout << "Hash function: " << hashfunc << endl;
+        cout << "Table size: " << tsize << endl;
+        cout << "Total words: " << totwords << endl;
+        cout << "Total collisions: " << col << endl;
+        cout << "Slots used: " << used << endl;
+        cout << "Max depth: " << maxdep << endl;
+        cout << "Add more entries to determine average depth" << endl;
+    }
 }
 
 /*

--- a/main.cpp
+++ b/main.cpp
@@ -41,7 +41,7 @@ int main()
                 break;
 
             case 2://select hash function
-                cout << endl << "Enter desired hash function (1-10):"<<endl;
+                cout << endl << "Enter desired hash function (1-4):"<<endl; //Used to read 1-10, but only four pre-built hash functions are available
                 getline(cin,t,'\n');
                 h.selectHashFunction(stoi(t));
                 break;


### PR DESCRIPTION
Line 161 in HashTab.cpp was causing a bug where when function #12 was called it would not return to the menu, you first had to provide an input, which would not be used. Removed the line, solving the issue. Also, line 44 in main.cpp was changed because it printed that options were 1-10 but examining the HashTab.cpp shows that only 1-4 are valid options for pre-built hash functions.
